### PR TITLE
Use Asselble.LoadFrom instead of Assembly.LoadFile

### DIFF
--- a/src/Moryx/Tools/AppDomainBuilder.cs
+++ b/src/Moryx/Tools/AppDomainBuilder.cs
@@ -24,8 +24,7 @@ namespace Moryx.Tools
 
                 try
                 {
-                    var assembly = Assembly.LoadFile(assemblyFile);
-                    AppDomain.CurrentDomain.Load(assembly.GetName());
+                    Assembly.LoadFrom(assemblyFile);
                 }
                 catch(Exception ex)
                 {


### PR DESCRIPTION
Identified in https://github.com/PHOENIXCONTACT/MORYX-Core/pull/110 and https://github.com/PHOENIXCONTACT/MORYX-ClientFramework/pull/28 loading assemblies with `LoadFile` will cause loading the assembly multiple times within the AppDomain in >.netcoreapp or >.net5 based applications.

[LoadFile vs. LoadFrom](https://docs.microsoft.com/en-us/archive/blogs/suzcook/loadfile-vs-loadfrom)