### PR TITLE
Fixed overriding endpoints in EndpointCollector

### DIFF
--- a/src/Moryx.Runtime.Kestrel/EndpointCollector.cs
+++ b/src/Moryx.Runtime.Kestrel/EndpointCollector.cs
@@ -9,7 +9,7 @@ namespace Moryx.Runtime.Kestrel
 {
     internal class EndpointCollector
     {
-        private readonly Dictionary<string, Endpoint> _endpoints = new Dictionary<string, Endpoint>();
+        private readonly ICollection<Endpoint> _endpoints = new List<Endpoint>();
 
         public Endpoint[] AllEndpoints
         {
@@ -17,24 +17,16 @@ namespace Moryx.Runtime.Kestrel
             {
                 lock (_endpoints)
                 {
-                    return _endpoints.Values.ToArray();
+                    return _endpoints.ToArray();
                 }
             }
         }
 
-        public void AddEndpoint(string address, Endpoint endpoint)
+        public void AddEndpoint(Endpoint endpoint)
         {
             lock (_endpoints)
             {
-                _endpoints[address] = endpoint;
-            }
-        }
-
-        public void RemoveEndpoint(string address)
-        {
-            lock (_endpoints)
-            {
-                _endpoints.Remove(address);
+                _endpoints.Add(endpoint);
             }
         }
     }

--- a/src/Moryx.Runtime.Kestrel/KestrelEndpointHosting.cs
+++ b/src/Moryx.Runtime.Kestrel/KestrelEndpointHosting.cs
@@ -98,7 +98,9 @@ namespace Moryx.Runtime.Kestrel
 
             var authorizeAttr = controller.GetCustomAttribute<AuthorizeAttribute>();
             var endpointAtt = controller.GetCustomAttribute<EndpointAttribute>();
-            _hostingContainer.Resolve<EndpointCollector>().AddEndpoint(address, new Endpoint
+
+            var endpointCollector = _hostingContainer.Resolve<EndpointCollector>();
+            endpointCollector.AddEndpoint(new Endpoint
             {
                 Address = address,
                 Path = route,

--- a/src/Moryx.Runtime.Kestrel/VersionController.cs
+++ b/src/Moryx.Runtime.Kestrel/VersionController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.Communication.Endpoints;
@@ -25,6 +26,7 @@ namespace Moryx.Runtime.Kestrel
             return Collector.AllEndpoints.Where(e => e.Service == service).ToArray();
         }
 
+        [Obsolete("Will be removed or returns array in the next major")]
         [HttpGet("endpoint/{endpoint}")]
         public Endpoint GetEndpointConfig(string endpoint)
         {


### PR DESCRIPTION
Services were overridden by their route because in asp.net it is possible to host several controllers at the same route.