### PR TITLE
Prevent queueing of modules that failed to initialize

### DIFF
--- a/src/Tests/Moryx.Tools.Wcf.SystemTests/VersionServiceTests.cs
+++ b/src/Tests/Moryx.Tools.Wcf.SystemTests/VersionServiceTests.cs
@@ -143,7 +143,7 @@ namespace Moryx.Tools.Wcf.SystemTests
 
             _hogController.StartService(ModuleController.ModuleName);
             result = _hogController.WaitForService(DependentTestModule.ModuleController.ModuleName, ServerModuleState.Running, 5);
-            Assert.IsTrue(result, "Service '{0}' did not reach state 'Running' ", ModuleController.ModuleName);
+            Assert.IsTrue(result, "Service '{0}' did not reach state 'Running' ", DependentTestModule.ModuleController.ModuleName);
 
             endpoints = _versionService.ActiveEndpoints();
 


### PR DESCRIPTION
Fixes #53 by preventing modules that failed to initialize and those with dependencies that failed to initialize to start