### PR TITLE
Fixed result of DefaultCanWriteValueProviderFilter for private setter

### DIFF
--- a/src/Moryx/Configuration/ValueProvider/Filters/DefaultCanWriteValueProviderFilter.cs
+++ b/src/Moryx/Configuration/ValueProvider/Filters/DefaultCanWriteValueProviderFilter.cs
@@ -13,7 +13,7 @@ namespace Moryx.Configuration
         /// <inheritdoc />
         public bool CheckProperty(PropertyInfo propertyInfo)
         {
-            return propertyInfo.CanWrite;
+            return propertyInfo.GetSetMethod() != null;
         }
     }
 }

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/DefaultCanWriteValueProviderFilterTests.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/DefaultCanWriteValueProviderFilterTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Configuration;
+using NUnit.Framework;
+
+namespace Moryx.Tests.Configuration.ValueProvider
+{
+    [TestFixture]
+    public class DefaultCanWriteValueProviderFilterTests
+    {
+        [Test(Description = "Test detects private setter right")]
+        public void DetectPrivateSetter()
+        {
+            // Arrange
+            var filter = new DefaultCanWriteValueProviderFilter();
+            var classType = typeof(PrivateSetterClass);
+            var privateSetterProperty = classType.GetProperty(nameof(PrivateSetterClass.PrivateSetterBool));
+            var noSetterProperty = classType.GetProperty(nameof(PrivateSetterClass.NoSetterBool));
+
+            // Act
+            var canWritePrivateSetter = filter.CheckProperty(privateSetterProperty);
+            var canWriteNoSetter = filter.CheckProperty(noSetterProperty);
+
+            // Assert
+            Assert.IsFalse(canWritePrivateSetter, "Private setter should be treated as not writable");
+            Assert.IsFalse(canWriteNoSetter, "No setter should be treated as not writable");
+        }
+
+        public class PrivateSetterClass
+        {
+            public bool PrivateSetterBool { get; private set; }
+
+            public bool NoSetterBool => false;
+        }
+    }
+}

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/ValueProviderTests.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/ValueProviderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Collections.Generic;
-using System.Linq;
 using Moryx.Configuration;
 using NUnit.Framework;
 
@@ -18,7 +17,6 @@ namespace Moryx.Tests.Configuration.ValueProvider
             var config = new TestConfig1();
 
             // Act
-
             ValueProviderExecutor.Execute(config, new ValueProviderExecutorSettings().AddDefaultValueProvider());
 
             // Assert


### PR DESCRIPTION
The result of `DefaultCanWriteValueProviderFilter` from the `ValueProvider` is returning wrong information:

````cs
public object Property { get; private set; } // property.CanWrite == true

private SomeClass _property;
public string Property => _property; // property.CanWrite == false
````

This leads to problems with read only properties (detected in `AbstractionLayer` task parameters)