### PR TITLE
Inherit ActiveLevel from Parentlogger.

### DIFF
--- a/src/Moryx/Logging/Logger.cs
+++ b/src/Moryx/Logging/Logger.cs
@@ -136,7 +136,7 @@ namespace Moryx.Logging
                 var config = _config.ChildConfigs.FirstOrDefault(item => item.LoggerName == childName);
                 if (config == null)
                 {
-                    config = new ModuleLoggerConfig { LoggerName = childName, ActiveLevel = Parent?.ActiveLevel ?? ActiveLevel.Info };
+                    config = new ModuleLoggerConfig { LoggerName = childName, ActiveLevel = Parent?.ActiveLevel ?? LogLevel.Info };
                     _config.ChildConfigs.Add(config);
                 }
 

--- a/src/Moryx/Logging/Logger.cs
+++ b/src/Moryx/Logging/Logger.cs
@@ -136,7 +136,7 @@ namespace Moryx.Logging
                 var config = _config.ChildConfigs.FirstOrDefault(item => item.LoggerName == childName);
                 if (config == null)
                 {
-                    config = new ModuleLoggerConfig { LoggerName = childName };
+                    config = new ModuleLoggerConfig { LoggerName = childName, ActiveLevel = Parent.ActiveLevel };
                     _config.ChildConfigs.Add(config);
                 }
 

--- a/src/Moryx/Logging/Logger.cs
+++ b/src/Moryx/Logging/Logger.cs
@@ -136,7 +136,7 @@ namespace Moryx.Logging
                 var config = _config.ChildConfigs.FirstOrDefault(item => item.LoggerName == childName);
                 if (config == null)
                 {
-                    config = new ModuleLoggerConfig { LoggerName = childName, ActiveLevel = Parent.ActiveLevel };
+                    config = new ModuleLoggerConfig { LoggerName = childName, ActiveLevel = Parent?.ActiveLevel ?? ActiveLevel.Info };
                     _config.ChildConfigs.Add(config);
                 }
 


### PR DESCRIPTION
It would be nice if ActiveLevels would be inherited. This way the default LogLevel would be maintained.