### PR TITLE
Add initialization of EntryValidation minimum & maximum properties

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryValidation.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryValidation.cs
@@ -36,6 +36,16 @@ namespace Moryx.Serialization
         [DataMember]
         public bool IsRequired { get; set; }
 
+        /// <summary>
+        /// Creates a new <see cref="EntryValidation"/> instance initializing <see cref="EntryValidation.Maximum"/> 
+        /// and <see cref="EntryValidation.Minimum"/> validation to the largest possible range.
+        /// </summary>
+        public EntryValidation()
+        {
+            Minimum = double.MinValue;
+            Maximum = double.MaxValue;
+        }
+
         /// <see cref="ICloneable"/>
         public object Clone()
         {


### PR DESCRIPTION
Currently EntryValidation instanzes are initialized with Minimum and Maximum parameters set to 0. If no validation is required an empty EntryValidation object thereby imposes a limitation to the available range nevertheless.
