### PR TITLE
Added missing proxy config handling

### DIFF
--- a/src/Moryx.Tools.Wcf/Client/Connector/WebHttpServiceConnectorBase.cs
+++ b/src/Moryx.Tools.Wcf/Client/Connector/WebHttpServiceConnectorBase.cs
@@ -118,8 +118,25 @@ namespace Moryx.Tools.Wcf
             // Compare version
             if (VersionCompare.ClientMatch(serverVersion, clientVersion))
             {
-                // Create new base address client
-                HttpClient = new HttpClient { BaseAddress = new Uri(endpoint.Address) };
+                // Create HttpClient
+                var proxyConfig = (_endpointService as IProxyConfigAccess)?.ProxyConfig;
+                if (proxyConfig?.EnableProxy == true && !proxyConfig.UseDefaultWebProxy)
+                {
+                    var proxy = new WebProxy
+                    {
+                        Address = new Uri($"http://{proxyConfig.Address}:{proxyConfig.Port}"),
+                        BypassProxyOnLocal = false,
+                        UseDefaultCredentials = true
+                    };
+
+                    HttpClient = new HttpClient(new HttpClientHandler { Proxy = proxy });
+                }
+                else
+                {
+                    HttpClient = new HttpClient();
+                }
+
+                HttpClient.BaseAddress = new Uri(endpoint.Address);
 
                 if (!string.IsNullOrEmpty(_myCulture.IetfLanguageTag))
                     HttpClient.DefaultRequestHeaders.AcceptLanguage

--- a/src/Moryx/Communication/Endpoints/Connector/IProxyConfigAccess.cs
+++ b/src/Moryx/Communication/Endpoints/Connector/IProxyConfigAccess.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Communication.Endpoints
+{
+    /// <summary>
+    /// Enables the access to the used proxy configuration
+    /// </summary>
+    public interface IProxyConfigAccess
+    {
+        /// <summary>
+        /// Used proxy configuration
+        /// </summary>
+        IProxyConfig ProxyConfig { get; }
+    }
+}

--- a/src/Moryx/Communication/Endpoints/Connector/VersionServiceManager.cs
+++ b/src/Moryx/Communication/Endpoints/Connector/VersionServiceManager.cs
@@ -13,7 +13,7 @@ namespace Moryx.Communication.Endpoints
     /// <summary>
     /// Service manager base class for provide active endpoints of the current application runtime
     /// </summary>
-    public abstract class VersionServiceManager<TEndpoint> : IVersionServiceManager
+    public abstract class VersionServiceManager<TEndpoint> : IVersionServiceManager, IProxyConfigAccess
         where TEndpoint : Endpoint
     {
         private const string ServiceName = "endpoints";
@@ -22,18 +22,23 @@ namespace Moryx.Communication.Endpoints
         /// Underlying http client for the requests
         /// </summary>
         protected HttpClient Client { get; set; }
+        
+        /// <inheritdoc/>
+        public IProxyConfig ProxyConfig { get; private set; }
 
         /// <summary>
         /// Creates a new instance of the <see cref="VersionServiceManager{TEndpoint}"/>
         /// </summary>
         protected VersionServiceManager(IProxyConfig proxyConfig, string host, int port)
         {
+            ProxyConfig = proxyConfig;
+
             // Create HttpClient
-            if (proxyConfig?.EnableProxy == true && !proxyConfig.UseDefaultWebProxy)
+            if (ProxyConfig?.EnableProxy == true && !ProxyConfig.UseDefaultWebProxy)
             {
                 var proxy = new WebProxy
                 {
-                    Address = new Uri($"http://{proxyConfig.Address}:{proxyConfig.Port}"),
+                    Address = new Uri($"http://{ProxyConfig.Address}:{ProxyConfig.Port}"),
                     BypassProxyOnLocal = false,
                     UseDefaultCredentials = true
                 };

--- a/src/Moryx/Communication/Endpoints/Connector/WebServiceConnectorBase.cs
+++ b/src/Moryx/Communication/Endpoints/Connector/WebServiceConnectorBase.cs
@@ -106,8 +106,25 @@ namespace Moryx.Communication.Endpoints
             // Compare version
             if (VersionCompare.ClientMatch(serverVersion, clientVersion))
             {
-                // Create new base address client
-                HttpClient = new HttpClient { BaseAddress = new Uri(endpoint.Address) };
+                // Create HttpClient
+                var proxyConfig = (_endpointService as IProxyConfigAccess)?.ProxyConfig;
+                if (proxyConfig?.EnableProxy == true && !proxyConfig.UseDefaultWebProxy)
+                {
+                    var proxy = new WebProxy
+                    {
+                        Address = new Uri($"http://{proxyConfig.Address}:{proxyConfig.Port}"),
+                        BypassProxyOnLocal = false,
+                        UseDefaultCredentials = true
+                    };
+
+                    HttpClient = new HttpClient(new HttpClientHandler { Proxy = proxy });
+                }
+                else
+                {
+                    HttpClient = new HttpClient();
+                }
+
+                HttpClient.BaseAddress = new Uri(endpoint.Address);
 
                 if (!string.IsNullOrEmpty(_myCulture.IetfLanguageTag))
                     HttpClient.DefaultRequestHeaders.AcceptLanguage


### PR DESCRIPTION
The proxy configuration is only be used in the ServiceVersionManager correctly and is missing in the other services.
So i made the proxy configuration accessible and used it in the other base classes to have the possibility to use the proxy configuration if necessary. 