### PR TITLE
Include MORYX kernel in service collection

### DIFF
--- a/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
+++ b/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net5.0</TargetFramework>
@@ -7,15 +7,14 @@
 		<PackageTags>MORYX;ASP</PackageTags>
 	</PropertyGroup>
 
-
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
-
 	<ItemGroup>
-	  <ProjectReference Include="..\Moryx.Runtime.Kernel\Moryx.Runtime.Kernel.csproj" />
-	  <ProjectReference Include="..\Moryx\Moryx.csproj" />
+      <ProjectReference Include="..\Moryx\Moryx.csproj" />
+      <ProjectReference Include="..\Moryx.Model\Moryx.Model.csproj" />
+      <ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Moryx.Asp.Extensions/MoryxServiceCollectionExtensions.cs
+++ b/src/Moryx.Asp.Extensions/MoryxServiceCollectionExtensions.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Moryx.Runtime.Kernel;
+using Moryx.Model;
+using Moryx.Runtime;
+using Moryx.Runtime.Configuration;
 using Moryx.Runtime.Modules;
 
 namespace Moryx.Asp.Integration
 {
     public static class MoryxServiceCollectionExtensions
     {
+        /// <summary>
+        /// Register MORYX facades in the service collection for module endpoints
+        /// </summary>
         public static void AddMoryxFacades(this IServiceCollection serviceCollection, IApplicationRuntime runtime)
         {
             var facadeCollector = runtime.GlobalContainer.Resolve<IFacadeCollector>();
@@ -24,6 +25,30 @@ namespace Moryx.Asp.Integration
                 {
                     serviceCollection.AddSingleton(facadeApi, facade);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Link MORYX kernel to the service collection
+        /// </summary>
+        public static void AddMoryxKernel(this IServiceCollection serviceCollection, IApplicationRuntime runtime)
+        {
+            // Fetch main kernel components
+            var configManager = runtime.GlobalContainer.Resolve<IRuntimeConfigManager>();
+            var moduleManager = runtime.GlobalContainer.Resolve<IModuleManager>();
+            var loggerManagement = runtime.GlobalContainer.Resolve<IServerLoggerManagement>();
+            var dbManager = runtime.GlobalContainer.Resolve<IDbContextManager>();
+
+            // Register in service collection
+            serviceCollection.AddSingleton(configManager);
+            serviceCollection.AddSingleton(moduleManager);
+            serviceCollection.AddSingleton(loggerManagement);
+            serviceCollection.AddSingleton(dbManager);
+
+            // Register all modules
+            foreach(var module in runtime.GlobalContainer.ResolveAll<IServerModule>())
+            {
+                serviceCollection.AddSingleton(module);
             }
         }
     }

--- a/src/StartProject.Asp/Pages/Index.cshtml
+++ b/src/StartProject.Asp/Pages/Index.cshtml
@@ -1,12 +1,30 @@
 ﻿@page
+@using Moryx.Runtime.Configuration
+@using Moryx.Runtime.Modules
 @using Moryx.TestModule
+@using Moryx.TestModule.Kestrel
 @model IndexModel
 @inject ITestFacade facade
+@inject IRuntimeConfigManager configManager
+@inject IEnumerable<IServerModule> modules
 @{
     ViewData["Title"] = "Home page";
+
+    var config = configManager.GetConfiguration<ModuleConfig>();
 }
 
 <div class="text-center">
     <h1 class="display-4">Welcome with @(facade.Bla)</h1>
     <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div>
+
+<ul>
+@foreach(var module in modules)
+{
+    <li>@(module.Name)</li>
+}
+</ul>
+
+<div>
+     <p>@(config.ConfigState)</p>
 </div>

--- a/src/StartProject.Asp/Startup.cs
+++ b/src/StartProject.Asp/Startup.cs
@@ -26,6 +26,8 @@ namespace StartProject.Asp
         {
             services.AddRazorPages();
 
+            services.AddMoryxKernel(_moryxRuntime);
+
             services.AddMoryxFacades(_moryxRuntime);
         }
 


### PR DESCRIPTION
In the first iteration we registed MORYX facades in the service collection to create endpoints and web UIs.

This links the kernel into the service collection, so the MaintenanceWeb can be migrated and also prepares switching the L1 composition completely to ASP.