### PR TITLE
Rename `Moryx.Runtime.Endpoints...NotificationModel`

### DIFF
--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/Models/ModuleNotificationModel.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/Models/ModuleNotificationModel.cs
@@ -10,12 +10,12 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint.Models
     /// <summary>
     /// Model for notifications.
     /// </summary>
-    public class NotificationModel
+    public class ModuleNotificationModel
     {
         /// <summary>
         /// Default constructor for serialization
         /// </summary>
-        public NotificationModel()
+        public ModuleNotificationModel()
         {
 
         }
@@ -24,7 +24,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint.Models
         /// Constructor for a notification.
         /// </summary>
         /// <param name="notification">A notification raisded by a module.</param>
-        public NotificationModel(IModuleNotification notification)
+        public ModuleNotificationModel(IModuleNotification notification)
         {
             Timestamp = notification.Timestamp;
             if(notification.Exception != null)

--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/Models/ServerModuleModel.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/Models/ServerModuleModel.cs
@@ -17,7 +17,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint.Models
         public ServerModuleModel()
         {
             Dependencies = new List<ServerModuleModel>();
-            Notifications = new NotificationModel[0];
+            Notifications = new ModuleNotificationModel[0];
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint.Models
         /// <summary>
         /// Contains a list of notifications for that model.
         /// </summary>
-        public NotificationModel[] Notifications { get; set; }
+        public ModuleNotificationModel[] Notifications { get; set; }
 
         /// <summary>
         /// The configured assembly.

--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
@@ -56,7 +56,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
                     HealthState = module.State,
                     StartBehaviour = _moduleManager.BehaviourAccess<ModuleStartBehaviour>(module).Behaviour,
                     FailureBehaviour = _moduleManager.BehaviourAccess<FailureBehaviour>(module).Behaviour,
-                    Notifications = notifications.Select(n => new NotificationModel(n)).ToArray()
+                    Notifications = notifications.Select(n => new ModuleNotificationModel(n)).ToArray()
                 };
 
                 var dependencies = _moduleManager.StartDependencies(module);
@@ -84,11 +84,11 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
         }
 
         [HttpGet("{moduleName}/notifications")]
-        public ActionResult<IEnumerable<NotificationModel>> Notifications([FromRoute] string moduleName)
+        public ActionResult<IEnumerable<ModuleNotificationModel>> Notifications([FromRoute] string moduleName)
         {
             var module = _moduleManager.AllModules.FirstOrDefault(m => m.Name == moduleName);
             if (module != null)
-                return Ok(module.Notifications.Select(n => new NotificationModel(n)));
+                return Ok(module.Notifications.Select(n => new ModuleNotificationModel(n)));
 
             return NotFound($"Module with name \"{moduleName}\" could not be found");
         }


### PR DESCRIPTION
The endpoints `NotificationModel` conflicted with the notifications `NotificationModel`,
which resulted in an exception when generating the swagger doc.

