### PR TITLE
Update to target net6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ env:
   MORYX_OPTIMIZE_CODE: "false"
   MORYX_BUILD_CONFIG: "Release"
   MORYX_BUILDNUMBER: ${{github.run_number}}
-  dotnet_sdk_version: '5.0.403'
+  dotnet_sdk_version: '6.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:

--- a/src/Moryx.Communication.Serial/Moryx.Communication.Serial.csproj
+++ b/src/Moryx.Communication.Serial/Moryx.Communication.Serial.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>MORYX binary connection for serial communication</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Container/Moryx.Container.csproj
+++ b/src/Moryx.Container/Moryx.Container.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>MORYX container functionality based on Castle.Windsor.</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.DependentTestModule/Moryx.DependentTestModule.csproj
+++ b/src/Moryx.DependentTestModule/Moryx.DependentTestModule.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Moryx Runtime Module: DependentTestModule</Description>
   </PropertyGroup>
 

--- a/src/Moryx.Maintenance.Web/Moryx.Maintenance.Web.csproj
+++ b/src/Moryx.Maintenance.Web/Moryx.Maintenance.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	<CreatePackage>true</CreatePackage>
   </PropertyGroup>
@@ -19,8 +19,10 @@
     </ItemGroup>
 
   <Target Name="BuildUI" BeforeTargets="Build" Condition="'$(Configuration)'!='Debug' Or !Exists('wwwroot\bundle.js')">
+	<Exec WorkingDirectory="./" Command="npm config set strict-ssl false" />
 	<Exec WorkingDirectory="./" Command="npm install" />
-	<Exec WorkingDirectory="./" Command="npm run build" />
+	<Exec WorkingDirectory="./" Command="npm run build --force" />
+	<Exec WorkingDirectory="./" Command="npm config set strict-ssl true" />
   </Target>
 
 </Project>

--- a/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
+++ b/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>InMemory extension for unit tests referencing Moryx.Model</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
+++ b/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Adapter for Moryx.Model on PostgreSQL</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
+++ b/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Adapter for Moryx.Model on Sqlite</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Model/Moryx.Model.csproj
+++ b/src/Moryx.Model/Moryx.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Datamodel integration for MORYX applications based on Entity Framework</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Runtime.Endpoints/Moryx.Runtime.Endpoints.csproj
+++ b/src/Moryx.Runtime.Endpoints/Moryx.Runtime.Endpoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <CreatePackage>true</CreatePackage>
     </PropertyGroup>
 

--- a/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
+++ b/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Kernel components that comprise the MORYX server side runtime environment</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Runtime/Moryx.Runtime.csproj
+++ b/src/Moryx.Runtime/Moryx.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Server side component types and implementations for MORYX applications</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.TestModule/Moryx.TestModule.csproj
+++ b/src/Moryx.TestModule/Moryx.TestModule.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <Description>Moryx Runtime Module: TestModuleKestrel.</Description>
         <OutputType>Library</OutputType>
     </PropertyGroup>

--- a/src/Moryx.TestTools.Test.Model/Moryx.TestTools.Test.Model.csproj
+++ b/src/Moryx.TestTools.Test.Model/Moryx.TestTools.Test.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.TestTools.UnitTest/Moryx.TestTools.UnitTest.csproj
+++ b/src/Moryx.TestTools.UnitTest/Moryx.TestTools.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Library with helper classes for UnitTests.</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx/Communication/Endpoints/Connector/VersionServiceManager.cs
+++ b/src/Moryx/Communication/Endpoints/Connector/VersionServiceManager.cs
@@ -48,7 +48,7 @@ namespace Moryx.Communication.Endpoints
             {
                 return ActiveEndpointsAsync().Result;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }
@@ -69,7 +69,7 @@ namespace Moryx.Communication.Endpoints
             {
                 return ServiceEndpointsAsync(service).Result;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }

--- a/src/Moryx/Moryx.csproj
+++ b/src/Moryx/Moryx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Core package of the MORYX ecosystem. It defines the necessary types for MORYX compatibility as well as commonly required tools.</Description>

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
 

--- a/src/Tests/Moryx.Communication.Sockets.IntegrationTests/Moryx.Communication.Sockets.IntegrationTests.csproj
+++ b/src/Tests/Moryx.Communication.Sockets.IntegrationTests/Moryx.Communication.Sockets.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/src/Tests/Moryx.Container.TestPlugin/Moryx.Container.TestPlugin.csproj
+++ b/src/Tests/Moryx.Container.TestPlugin/Moryx.Container.TestPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Container.TestRootPlugin/Moryx.Container.TestRootPlugin.csproj
+++ b/src/Tests/Moryx.Container.TestRootPlugin/Moryx.Container.TestRootPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Container.TestTools/Moryx.Container.TestTools.csproj
+++ b/src/Tests/Moryx.Container.TestTools/Moryx.Container.TestTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
+++ b/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.Model.Tests/Moryx.Model.Tests.csproj
+++ b/src/Tests/Moryx.Model.Tests/Moryx.Model.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.Tests/Moryx.Tests.csproj
+++ b/src/Tests/Moryx.Tests/Moryx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
.net5 is already deprecated. Therefore, we need to target .net6 with the next major