### PR TITLE
Proposed change for the treatment of null values in the ValueProvider

### DIFF
--- a/src/Moryx/Configuration/ValueProvider/IValueProviderValidator.cs
+++ b/src/Moryx/Configuration/ValueProvider/IValueProviderValidator.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Reflection;
+
+namespace Moryx.Configuration
+{
+    /// <summary>
+    /// Interface for validators that ensure properties have been filled as expected
+    /// </summary>
+    public interface IValueProviderValidator
+    {
+        /// <summary>
+        /// Checks the property if it was correctly set by a value provider
+        /// </summary>
+        /// <param name="propertyInfo">Property to check</param>
+        /// <param name="target">Object the property is on. Can be used to access the value for instance</param>
+        /// <returns>True if the property was correctly set</returns>
+        bool CheckProperty(PropertyInfo propertyInfo, object target);
+    }
+}

--- a/src/Moryx/Configuration/ValueProvider/PropertyValidationException.cs
+++ b/src/Moryx/Configuration/ValueProvider/PropertyValidationException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Moryx.Configuration
+{
+    [Serializable]
+    internal class PropertyValidationException : Exception
+    {
+        private PropertyInfo property;
+        private ValueProviderExecutorSettings settings;
+
+        public PropertyValidationException()
+        {
+        }
+
+        public PropertyValidationException(string message) : base(message)
+        {
+        }
+
+        public PropertyValidationException(PropertyInfo property, ValueProviderExecutorSettings settings) 
+            : this($"Failed to provide acceptable value for property {property.Name} on type {property.DeclaringType}")
+        {
+            this.property = property;
+            this.settings = settings;
+        }
+
+    }
+}

--- a/src/Moryx/Configuration/ValueProvider/Providers/ActivatorValueProvider.cs
+++ b/src/Moryx/Configuration/ValueProvider/Providers/ActivatorValueProvider.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Reflection;
+
+namespace Moryx.Configuration
+{
+    /// <summary>
+    /// Uses the activator on properties of classes with a default constructor
+    /// </summary>
+    public sealed class ActivatorValueProvider : IValueProvider
+    {
+        /// <inheritdoc/>
+        public ValueProviderResult Handle(object parent, PropertyInfo property)
+        {
+
+            var propertyType = property.PropertyType;
+            var value = property.GetValue(parent);
+
+            if (propertyType.IsClass && value == null && !propertyType.IsAbstract && propertyType != typeof(string))
+            {
+                if (propertyType.IsArray)
+                {
+                    var elementType = propertyType.GetElementType();
+
+                    if (elementType == null)
+                    {
+                        return ValueProviderResult.Skipped;
+                    }
+
+
+                    property.SetValue(parent, Array.CreateInstance(elementType, 0));
+                    return ValueProviderResult.Handled;
+                }
+
+                var ctor = propertyType.GetConstructor(Type.EmptyTypes);
+                if (ctor != null)
+                {
+                    property.SetValue(parent, Activator.CreateInstance(propertyType));
+                    return ValueProviderResult.Handled;
+                }
+            }
+            return ValueProviderResult.Skipped;
+        }
+    }
+}

--- a/src/Moryx/Configuration/ValueProvider/Providers/DefaultValueAttributeProvider.cs
+++ b/src/Moryx/Configuration/ValueProvider/Providers/DefaultValueAttributeProvider.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace Moryx.Configuration
+{
+    /// <summary>
+    /// Applies values from <see cref="DefaultValueAttribute"/> on the properties
+    /// </summary>
+    public sealed class DefaultValueAttributeProvider : IValueProvider
+    {
+        private static object DefaultValue(Type propType)
+        {
+            return propType.IsValueType ? Activator.CreateInstance(propType) : null;
+        }
+
+        /// <inheritdoc/>
+        public ValueProviderResult Handle(object parent, PropertyInfo property)
+        {
+            var propertyType = property.PropertyType;
+            var value = property.GetValue(parent);
+            
+            if (Equals(value, DefaultValue(propertyType)))
+            {
+                var attribute = property.GetCustomAttribute<DefaultValueAttribute>(false);
+                if (attribute != null)
+                {
+                    // Accept nulls for objects or nullable reference types
+                    if (attribute.Value == null && (propertyType.IsClass || Nullable.GetUnderlyingType(propertyType) != null))
+                    {
+                        property.SetValue(parent, value);
+                        return ValueProviderResult.Handled;
+                    }
+
+                    // Return if type matches
+                    if (property.PropertyType.IsInstanceOfType(attribute.Value))
+                    {
+                        property.SetValue(parent, attribute.Value);
+                        return ValueProviderResult.Handled;
+                    }
+
+                    // Try to convert
+                    try
+                    {
+                        property.SetValue(parent, Convert.ChangeType(attribute.Value, propertyType));
+                        return ValueProviderResult.Handled;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            return ValueProviderResult.Skipped;
+        }
+    }
+}

--- a/src/Moryx/Configuration/ValueProvider/Providers/DefaultValueProvider.cs
+++ b/src/Moryx/Configuration/ValueProvider/Providers/DefaultValueProvider.cs
@@ -7,94 +7,25 @@ using System.Reflection;
 
 namespace Moryx.Configuration
 {
+
     /// <summary>
-    /// ValueProvider that sets property's value given from a <see cref="DefaultValueAttribute"/>
+    /// Old DefaultValueProvider for compatibility reasons.
+    /// It is equivalent to using the <see cref="DefaultValueAttributeProvider" /> and the <see cref="ActivatorValueProvider" /> in series
     /// </summary>
+    [Obsolete]
     public sealed class DefaultValueProvider : IValueProvider
     {
+
+        private DefaultValueAttributeProvider defaultValueAttributeProvider = new DefaultValueAttributeProvider();
+        private ActivatorValueProvider activatorValueProvider = new ActivatorValueProvider();
+        
         /// <inheritdoc />
         public ValueProviderResult Handle(object parent, PropertyInfo property)
         {
-            var propType = property.PropertyType;
-
-            // Provide default entries
-            var value = property.GetValue(parent);
-            
-            if (Equals(value, DefaultValue(propType)))
-            {
-                if(ProvideDefaultValue(property, out value))
-                {
-                    property.SetValue(parent, value);
-
-                    return ValueProviderResult.Handled;
-                }
-            }
-
+            if (activatorValueProvider.Handle(parent, property) == ValueProviderResult.Skipped)
+                return defaultValueAttributeProvider.Handle(parent, property);
             return ValueProviderResult.Skipped;
         }
 
-        private static object DefaultValue(Type propType)
-        {
-            return propType.IsValueType ? Activator.CreateInstance(propType) : null;
-        }
-
-        private static bool ProvideDefaultValue(PropertyInfo property, out object defaultValue)
-        {
-            var propertyType = property.PropertyType;
-            defaultValue = null;
-
-            var attribute = property.GetCustomAttribute<DefaultValueAttribute>(false);
-            if(attribute != null)
-            {
-                // Accept nulls for objects or nullable reference types
-                if(attribute.Value == null && (propertyType.IsClass || Nullable.GetUnderlyingType(propertyType) != null)) {
-                    return true;
-                }
-
-                // Return if type matches
-                if (property.PropertyType.IsInstanceOfType(attribute.Value))
-                {
-                    defaultValue = attribute.Value;
-                    return true;
-                }
-
-                
-
-                // Try to convert
-                try
-                {
-                    defaultValue = Convert.ChangeType(attribute.Value, propertyType);
-                    return true;
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-
-
-            if (propertyType.IsClass && !propertyType.IsAbstract && propertyType != typeof(string))
-            {
-                if (propertyType.IsArray)
-                {
-                    var elementType = propertyType.GetElementType();
-
-                    if (elementType == null)
-                    {
-                        return false;
-                    }
-                        
-
-                    defaultValue = Array.CreateInstance(elementType, 0);
-                    return true;
-                }
-
-                defaultValue = Activator.CreateInstance(propertyType);
-                return true;
-
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Moryx/Configuration/ValueProvider/Validators/ConcreteClassesInitializedValidator.cs
+++ b/src/Moryx/Configuration/ValueProvider/Validators/ConcreteClassesInitializedValidator.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+
+namespace Moryx.Configuration
+{
+    /// <summary>
+    /// Makes sure that all fields with a class type were filled
+    /// </summary>
+    public class ConcreteClassesInitializedValidator : IValueProviderValidator
+    {
+        /// <inheritdoc/>
+        public bool CheckProperty(PropertyInfo propertyInfo, object parentObject)
+        {
+            if(propertyInfo.PropertyType.IsClass && !propertyInfo.PropertyType.IsAbstract)
+            {
+                return propertyInfo.GetValue(parentObject) != null;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
+++ b/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
@@ -36,6 +36,11 @@ namespace Moryx.Configuration
         /// <exception cref="ArgumentNullException"></exception>
         public static void Execute(object targetObject, ValueProviderExecutorSettings settings)
         {
+            if (targetObject is null)
+            {
+                throw new ArgumentNullException(nameof(targetObject));
+            }
+
             if (settings.Providers == null)
             {
                 throw new ArgumentNullException(nameof(settings.Providers));
@@ -46,11 +51,17 @@ namespace Moryx.Configuration
                 throw new ArgumentNullException(nameof(settings.Filters));
             }
 
+            
             Iterate(targetObject, settings);
         }
 
         private static void Iterate(object target, ValueProviderExecutorSettings settings)
         {
+            if (target is null)
+            {
+                return;
+            }
+
             foreach (var property in FilterProperties(target, settings))
             {
                 foreach (var settingsProvider in settings.Providers)
@@ -62,6 +73,7 @@ namespace Moryx.Configuration
                 }
 
                 var value = property.GetValue(target);
+
 
                 if (property.PropertyType.IsValueType && !property.PropertyType.IsPrimitive ||
                      property.PropertyType.IsClass &&

--- a/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
+++ b/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
@@ -64,14 +64,30 @@ namespace Moryx.Configuration
 
             foreach (var property in FilterProperties(target, settings))
             {
+                
                 foreach (var settingsProvider in settings.Providers)
                 {
-                    if (settingsProvider.Handle(target, property) == ValueProviderResult.Handled)
+                    try
                     {
-                        break;
+                        if (settingsProvider.Handle(target, property) == ValueProviderResult.Handled)
+                        {
+                
+                            break;
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        // TODO: Restrict exceception type
+                        // TODO: Consider enabling logging
                     }
                 }
 
+                if(settings.Validators.Any(validator => !validator.CheckProperty(property, target)))
+                {
+                    throw new PropertyValidationException(property, settings);
+                }
+
+                
                 var value = property.GetValue(target);
 
 

--- a/src/Moryx/Configuration/ValueProvider/ValueProviderExecutorSettings.cs
+++ b/src/Moryx/Configuration/ValueProvider/ValueProviderExecutorSettings.cs
@@ -15,6 +15,8 @@ namespace Moryx.Configuration
 
         private readonly List<IValueProviderFilter> _filters = new List<IValueProviderFilter> { new DefaultCanWriteValueProviderFilter() };
 
+        private readonly List<IValueProviderValidator> _validators = new List<IValueProviderValidator>();
+
         /// <summary>
         /// Configured filters
         /// </summary>
@@ -24,6 +26,11 @@ namespace Moryx.Configuration
         /// Configured providers
         /// </summary>
         public IEnumerable<IValueProvider> Providers => _providers;
+
+        /// <summary>
+        /// Configured Validators
+        /// </summary>
+        public IEnumerable<IValueProviderValidator> Validators => _validators;
 
         /// <summary>
         /// Configured <see cref="BindingFlags"/>
@@ -69,7 +76,9 @@ namespace Moryx.Configuration
         /// <returns></returns>
         public ValueProviderExecutorSettings AddDefaultValueProvider()
         {
-            return AddProvider(new DefaultValueProvider());
+            return AddProvider(new DefaultValueAttributeProvider())
+                .AddProvider(new ActivatorValueProvider());
+
         }
     }
 }

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/TestConfig5.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/TestConfig5.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.ComponentModel;
+
+namespace Moryx.Tests.Configuration.ValueProvider
+{
+    internal class ClassWithoutParamLessCtor
+    {
+        public ClassWithoutParamLessCtor(string a)
+        {
+
+        }
+    }
+
+    internal class TestConfig5
+    {
+        [DefaultValue(null)]
+        public ClassWithoutParamLessCtor Field1 { get; set; }
+
+        [DefaultValue(null)]
+        public Func<string, bool> Field2 { get; set; }
+    }
+}

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/TestConfig6.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/TestConfig6.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+
+namespace Moryx.Tests.Configuration.ValueProvider
+{
+    internal class TestConfig6
+    {
+        public TestConfig6()
+        {
+        }
+
+        [DefaultValue(5)]
+        public int? WithDefaultValue { get; set; }
+
+        [DefaultValue(null)]
+        public int? WithDefaultValueNull { get; set; }
+
+        public int? WithoutDefaultValue { get; set; }
+    }
+}

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/ThreeProvider.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/ThreeProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Configuration;
+using System.Reflection;
+
+namespace Moryx.Tests.Configuration.ValueProvider
+{
+    internal class ThreeProvider : IValueProvider
+    {
+        public ValueProviderResult Handle(object parent, PropertyInfo property)
+        {
+            property.SetValue(parent, 3);
+            return ValueProviderResult.Handled;
+        }
+    }
+}

--- a/src/Tests/Moryx.Tests/Configuration/ValueProvider/ValueProviderTests.cs
+++ b/src/Tests/Moryx.Tests/Configuration/ValueProvider/ValueProviderTests.cs
@@ -127,5 +127,30 @@ namespace Moryx.Tests.Configuration.ValueProvider
             Assert.NotNull(config.ArrayNumbers);
             Assert.IsNull(config.EnumerableNumbers);
         }
+
+        [Test]
+        public void PropertyWithoutDefaultCtorDoesNotThrow()
+        {
+            // Arrange
+            var config = new TestConfig5();
+            var settings = new ValueProviderExecutorSettings().AddDefaultValueProvider();
+            
+            // Act
+            // Assert
+            Assert.DoesNotThrow(() => ValueProviderExecutor.Execute(config, settings));
+        }
+
+        [Test]
+        public void NullableValueTypesHandledCorrectly()
+        {
+            var config = new TestConfig6();
+
+            // Act
+            ValueProviderExecutor.Execute(config, new ValueProviderExecutorSettings().AddDefaultValueProvider().AddProvider(new ThreeProvider()));
+
+            Assert.AreEqual(5, config.WithDefaultValue, "Not null default value was not applied");
+            Assert.IsNull(config.WithDefaultValueNull, "Did not respect default value null");
+            Assert.AreEqual(3, config.WithoutDefaultValue, "DefaultValueProvider did handle the field without a DefaultValue Attribute");
+        }
     }
 }


### PR DESCRIPTION
### Summary

This pull request tries to adress some pain point I have encounterd while working with the serialization in MORYX related to default values.

Problems:
1. Using nullable value types does only work when specifing a DefaultValue that is not `null`.
    -  throws a NullReferenceException in the FilterProperties Method of the ValueProviderExecutor
    - Because the DefaultValueProvider does not return "Handled" when the default value is set to `null` the property could be passed to another provider although a DefaultValue is explicitly specified
3. Can't have types without a parameterless comstructor, even on fields that schould not be serialized
    -  Leads to a MethodNotFound Exception because Activator.CreateInstance can't find a paramless ctor.

Proposed solution:
1. ValueProviderExecutor 
    -  Stopping the iteration on a null value
5. DefaultValueProvider
    - Checking the DefaultValueAttribute before trying to create a new instance of the properties type
    - Making the ValueProviderResult indepent of the returned default value beeing null or not

Effect: Nullable properties can be marked with DefaultValue(null) to explicity say that they should not be initialized with any value.






### Relevant logs and/or screenshots



### Review

<!-- 
The bullet points will be edited by the reviewer 
-->

**Typical tasks**

- [ ] Merge-Request is well described
- [ ] Added `Obsolete` attributes if necessary
- [ ] Critical sections are *documented in code*
- [ ] *Tests* available or extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] *Manual* is created / updated

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets



