### PR TITLE
Change build ui step to be executed before PrepareForBuild

### DIFF
--- a/src/Moryx.Maintenance.Web/Moryx.Maintenance.Web.csproj
+++ b/src/Moryx.Maintenance.Web/Moryx.Maintenance.Web.csproj
@@ -18,7 +18,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
-  <Target Name="BuildUI" BeforeTargets="Build" Condition="'$(Configuration)'!='Debug' Or !Exists('wwwroot\bundle.js')">
+  <Target Name="BuildUI" BeforeTargets="PrepareForBuild" Condition="'$(Configuration)'!='Debug' Or !Exists('wwwroot\bundle.js')">
 	<Exec WorkingDirectory="./" Command="npm config set strict-ssl false" />
 	<Exec WorkingDirectory="./" Command="npm install" />
 	<Exec WorkingDirectory="./" Command="npm run build --force" />


### PR DESCRIPTION
Since the update to .net6 the content of the wwwroot directory was not included in the staticwebassets in the package, but in the contentfiles directory instead.

The integrated Typescript support of .net6 provides options to build typescript code in RCLs before the PrepareForBuild target. For more info see [the microsoft documentation](https://learn.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-6.0&tabs=visual-studio#typescript-integration). Executing our UI build step before this target as well, solved the issue.