### PR TITLE
Add `Position` property to `WorkplanNode`

### DIFF
--- a/src/Moryx/Workflows/API/Type/IWorkplanNode.cs
+++ b/src/Moryx/Workflows/API/Type/IWorkplanNode.cs
@@ -17,5 +17,26 @@ namespace Moryx.Workplans
         /// Transition name
         /// </summary>
         string Name { get; set; }
+
+        /// <summary>
+        /// Position of this node
+        /// </summary>
+        WorkplanNodePosition Position { get; set; }
+    }
+
+    /// <summary>
+    /// Position of a workplan node
+    /// </summary>
+    public class WorkplanNodePosition
+    {
+        /// <summary>
+        /// X coordinate
+        /// </summary>
+        public long X { get; set; }
+
+        /// <summary>
+        /// Y coordinate
+        /// </summary>
+        public long Y { get; set; }
     }
 }

--- a/src/Moryx/Workflows/Implementation/Connector.cs
+++ b/src/Moryx/Workflows/Implementation/Connector.cs
@@ -19,6 +19,10 @@ namespace Moryx.Workplans
         [DataMember]
         public string Name { get; set; }
 
+        ///
+        [DataMember]
+        public WorkplanNodePosition Position { get; set; } = new WorkplanNodePosition();
+
         /// 
         [DataMember]
         public NodeClassification Classification { get; set; }

--- a/src/Moryx/Workflows/WorkplanSteps/WorkplanStepBase.cs
+++ b/src/Moryx/Workflows/WorkplanSteps/WorkplanStepBase.cs
@@ -45,6 +45,10 @@ namespace Moryx.Workplans.WorkplanSteps
         public OutputDescription[] OutputDescriptions { get; set; }
 
         ///
+        [DataMember]
+        public WorkplanNodePosition Position { get; set; } = new WorkplanNodePosition();
+
+        ///
         public ITransition CreateInstance(IWorkplanContext context)
         {
             var transition = Instantiate(context);


### PR DESCRIPTION
To have position information at the base of a `WorkplanNode` it's extendet by the `Position` property of type `WorkplanNodePosition`.

