### PR TITLE
Remove ExecuteCommand from IServerModuleConsole

### DIFF
--- a/src/Moryx.DependentTestModule/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.DependentTestModule/ModuleController/ModuleConsole.cs
@@ -19,11 +19,6 @@ namespace Moryx.DependentTestModule
 
         #endregion
 
-        public void ExecuteCommand(string[] args, Action<string> outputStream)
-        {
-            outputStream("The DependentTestModule does not provide any commands!");
-        }
-
         [EntrySerialize, Description("Creates a log message for the given log level")]
         public void CreateTestLogMessage(LogLevel logLevel)
         {

--- a/src/Moryx.Products.Management/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.Products.Management/ModuleController/ModuleConsole.cs
@@ -17,23 +17,7 @@ namespace Moryx.Products.Management
     {
         public AutoConfigurator Configurator { get; set; }
 
-        public IConfigManager ConfigManager { get; set; }
-
-        public void ExecuteCommand(string[] args, Action<string> outputStream)
-        {
-            if (!args.Any())
-                outputStream("ProductManagement console requires arguments");
-
-            switch (args[0])
-            {
-                case "configure":
-                    var product = args.Length >= 2 ? args[1] : null;
-                    outputStream($"Running configurator for {product}");
-                    var result = Configurator.ConfigureType(product);
-                    outputStream(result);
-                    break;
-            }
-        }
+        public IConfigManager ConfigManager { get; set; }       
 
         [EntrySerialize]
         [Description("Automatically configure the necessary strategies for a product type.")]

--- a/src/Moryx.Resources.Management/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleConsole.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.ComponentModel;
-using System.Linq;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Runtime.Modules;
 using Moryx.Serialization;
-using Moryx.Tools;
 
 namespace Moryx.Resources.Management
 {
@@ -37,110 +35,7 @@ namespace Moryx.Resources.Management
 
         private IResourceInitializer[] _initializers;
 
-        #endregion
-
-        public void ExecuteCommand(string[] args, Action<string> outputStream)
-        {
-            if (args.Length <= 0)
-                return;
-
-            switch (args[0].ToLower())
-            {
-                case "initialize":
-                    Initialize(args.Skip(1).ToArray(), outputStream);
-                    break;
-            }
-        }
-
-        private void Initialize(string[] args, Action<string> outputStream)
-        {
-            // If not executed, create instances of the initializers
-            if (_initializers == null)
-                _initializers = ModuleConfig.Initializers.Select(config => InitializerFactory.Create(config)).ToArray();
-
-            // If no additional arguments, list initializers
-            if (!args.Any())
-            {
-                ListResourceInitializers(outputStream);
-                return;
-            }
-
-            // If argument is 'list', list initializers
-            if (args[0].ToLower() == "list")
-            {
-                ListResourceInitializers(outputStream);
-                return;
-            }
-
-            // Else, parse argument
-            outputStream(string.Empty);
-            int initializerPos;
-            if (int.TryParse(args[0], out initializerPos))
-            {
-                var index = initializerPos - 1;
-                if (index >= _initializers.Length)
-                {
-                    outputStream($"ResourceInitializer with position {initializerPos} does not exists");
-                    ListResourceInitializers(outputStream);
-                }
-
-                var initializer = _initializers[initializerPos - 1];
-                ExecuteInitializer(initializer, outputStream);
-            }
-            else
-            {
-                var name = args[0];
-                var initializer = _initializers.SingleOrDefault(i => i.Name.Replace(" ", "-").ToLower().Equals(name.ToLower()));
-
-                if (initializer == null)
-                {
-                    outputStream($"ResourceInitializer with name '{name}' does not exists");
-                    ListResourceInitializers(outputStream);
-                }
-                else
-                {
-                    ExecuteInitializer(initializer, outputStream);
-                }
-            }
-        }
-
-        private void ExecuteInitializer(IResourceInitializer initializer, Action<string> outputStream)
-        {
-            try
-            {
-                outputStream($"Executing initializer '{initializer.Name}' ...");
-                ResourceManager.ExecuteInitializer(initializer);
-                outputStream("Successful! Restart the module to load the changes!");
-                outputStream(string.Empty);
-            }
-            catch (Exception e)
-            {
-                outputStream(ExceptionPrinter.Print(e));
-                outputStream("... initialization failed!");
-            }
-        }
-
-        private void ListResourceInitializers(Action<string> outputStream)
-        {
-            var maxName = _initializers.Max(i => i.Name.Length) + 2;
-
-            outputStream($"|{"Id",-5}|{"Name".PadRight(maxName)}|Description");
-            outputStream($"|-----|{"-".PadRight(maxName, '-')}|----------------");
-
-            for (var index = 0; index < _initializers.Length; index++)
-            {
-                var initializer = _initializers[index];
-                var name = initializer.Name.Replace(" ", "-");
-
-                var line = $"|{index + 1,-5}|{name.PadRight(maxName)}|{initializer.Description}";
-
-                outputStream(line);
-            }
-
-            outputStream($"{Environment.NewLine}Execute initializer with: {Environment.NewLine}" +
-                         $"- initialize <Id> {Environment.NewLine}" +
-                         $"- initialize <Name>{Environment.NewLine}");
-        }
+        #endregion     
 
         [EntrySerialize, DisplayName("Initialize Resource"), Description("Calls the configured resource initializer")]
         public string CallResourceInitializer([PluginConfigs(typeof(IResourceInitializer), true)] ResourceInitializerConfig[] configs)

--- a/src/Moryx.Runtime/Modules/IServerModuleConsole.cs
+++ b/src/Moryx.Runtime/Modules/IServerModuleConsole.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System;
-
 namespace Moryx.Runtime.Modules
 {
     /// <summary>
@@ -10,11 +8,6 @@ namespace Moryx.Runtime.Modules
     /// </summary>
     public interface IServerModuleConsole
     {
-        /// <summary>
-        /// Pass a command to this module
-        /// </summary>
-        /// <param name="args">Arguments passed to the module</param>
-        /// <param name="outputStream">Output stream to be used for feedback</param>
-        void ExecuteCommand(string[] args, Action<string> outputStream);
+      
     }
 }

--- a/src/Moryx.TestModule/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.TestModule/ModuleController/ModuleConsole.cs
@@ -61,11 +61,6 @@ namespace Moryx.TestModule
     {
         public IContainer Container { get; set; }
 
-        public void ExecuteCommand(string[] args, Action<string> outputStream)
-        {
-            outputStream("The TestModule does not provide any commands!");
-        }
-
         [EntrySerialize, Description("Returns the string that was sent.")]
         public string Echo(string message)
         {


### PR DESCRIPTION
Remove ExecuteCommand from IServerModuleConsole since there is no console in the new version anymore