### PR TITLE
Fix entity id link in products and resources modules

### DIFF
--- a/src/Moryx.Model/Extensions/UnitOfWorkExtensions.cs
+++ b/src/Moryx.Model/Extensions/UnitOfWorkExtensions.cs
@@ -21,10 +21,7 @@ namespace Moryx.Model
         {
             var entity = unitOfWork.FindEntity<TEntity>(obj);
 
-            if (entity == null)
-            {
-                entity = unitOfWork.CreateEntity<TEntity>(obj);
-            }
+            entity ??= unitOfWork.CreateEntity<TEntity>(obj);
 
             return entity;
         }

--- a/src/Moryx.Model/Repositories/UnitOfWork.cs
+++ b/src/Moryx.Model/Repositories/UnitOfWork.cs
@@ -22,7 +22,7 @@ namespace Moryx.Model.Repositories
         /// <inheritdoc />
         DbContext IUnitOfWork.DbContext => DbContext;
 
-        private Dictionary<IPersistentObject, IEntity> _entityBusinessObjectLinks = new Dictionary<IPersistentObject, IEntity>();
+        private readonly Dictionary<IPersistentObject, IEntity> _entityBusinessObjectLinks = new();
 
         /// <summary>
         /// Creates a new instance of <see cref="UnitOfWork{TContext}"/>
@@ -57,7 +57,7 @@ namespace Moryx.Model.Repositories
         /// <inheritdoc />
         public void LinkEntityToBusinessObject (IPersistentObject businessObject, IEntity entity)
         {
-            _entityBusinessObjectLinks.Add(businessObject, entity);
+            _entityBusinessObjectLinks[businessObject] = entity;
         }
 
         /// <inheritdoc />

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -595,7 +595,7 @@ namespace Moryx.Products.Management
             if (entities.All(p => p.Deleted != null))
             {
                 typeEntity = repo.Create(identity.Identifier, identity.Revision, modifiedInstance.Name, modifiedInstance.GetType().FullName);
-              
+                saverContext.UnitOfWork.LinkEntityToBusinessObject(modifiedInstance, typeEntity);
             }
             else
             {
@@ -629,6 +629,7 @@ namespace Moryx.Products.Management
                     if (linkEntity == null && link != null) // link is new
                     {
                         linkEntity = linkRepo.Create(linkStrategy.PropertyName);
+                        saverContext.UnitOfWork.LinkEntityToBusinessObject(link, linkEntity);
                         linkEntity.Parent = typeEntity;
                         linkStrategy.SavePartLink(link, linkEntity);                     
                         linkEntity.Child = GetPartEntity(saverContext, link);
@@ -668,9 +669,8 @@ namespace Moryx.Products.Management
                         if (link.Id == 0 || (linkEntity = currentEntities.FirstOrDefault(p => p.Id == link.Id)) == null)
                         {
                             linkEntity = linkRepo.Create(linkStrategy.PropertyName);
+                            saverContext.UnitOfWork.LinkEntityToBusinessObject(link, linkEntity);
                             linkEntity.Parent = typeEntity;
-                          
-                            
                         }
                         else
                         {
@@ -919,23 +919,14 @@ namespace Moryx.Products.Management
         /// </summary>
         public void SaveInstances(ProductInstance[] productInstances)
         {
-            using (var uow = Factory.Create())
-            {
-                var tuples = new Dictionary<ProductInstance, ProductInstanceEntity>();
-                // Write all to entity objects
-                foreach (var instance in productInstances)
-                {
-                    var entity = SaveInstance(uow, instance);
-                    tuples.Add(instance, entity);
-                }
+            using var uow = Factory.Create();
 
-                // Save transaction
-                uow.SaveChanges();
-                foreach(var tuple in tuples)
-                {
-                    tuple.Key.Id = tuple.Value.Id;
-                }
-            }
+            // Write all to entity objects
+            foreach (var instance in productInstances)
+                SaveInstance(uow, instance);
+
+            // Save transaction
+            uow.SaveChanges();
         }
 
         /// <summary>

--- a/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
@@ -88,16 +88,14 @@ namespace Moryx.Resources.Management
         /// <summary>
         /// Save the resource instance to a database entity
         /// </summary>
-        public static Tuple<ResourceEntity, bool> SaveToEntity(IUnitOfWork uow, Resource instance)
+        public static ResourceEntity SaveToEntity(IUnitOfWork uow, Resource instance)
         {
-            var wasCreated = false;
             // Create entity and populate from object
             var entity = uow.FindEntity<ResourceEntity>(instance);
-            if (entity == null)
+            if (entity is null)
             {
                 entity = uow.CreateEntity<ResourceEntity>(instance);
                 entity.Type = instance.ResourceType();
-                wasCreated = true;
             }
 
             // All those checks are necessary since EF change tracker does not recognize equal values as such
@@ -109,7 +107,7 @@ namespace Moryx.Resources.Management
             if (entity.ExtensionData != extensionData)
                 entity.ExtensionData = extensionData;
 
-            return new (entity, wasCreated);
+            return entity;
         }
 
         /// <summary>

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -375,7 +375,7 @@ namespace Moryx.Resources.Management
             }
             else
             {
-                entity = ResourceEntityAccessor.SaveToEntity(context.UnitOfWork, instance).Item1;
+                entity = ResourceEntityAccessor.SaveToEntity(context.UnitOfWork, instance);
                 context.ResourceLookup[entity] = instance;
             }
 

--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -300,8 +300,8 @@ namespace Moryx.Resources.Management
                 var newResources = new HashSet<Resource>();
 
                 var saveResult = ResourceEntityAccessor.SaveToEntity(uow, resource);
-                var entity = saveResult.Item1;
-                if (saveResult.Item2)
+                var entity = saveResult;
+                if (entity.Id == 0)
                     newResources.Add(resource);
 
                 var references = new Dictionary<Resource, ResourceEntity>();

--- a/src/Tests/Moryx.Resources.Management.Tests/ResourceEntityAccessorTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/ResourceEntityAccessorTests.cs
@@ -96,7 +96,7 @@ namespace Moryx.Resources.Management.Tests
             var extensionDataJson = JsonConvert.SerializeObject(resource, JsonSettings.Minimal);
 
             // Act
-            var resourceEntity = ResourceEntityAccessor.SaveToEntity(unitOfWorkMock.Object, resource).Item1;
+            var resourceEntity = ResourceEntityAccessor.SaveToEntity(unitOfWorkMock.Object, resource);
 
             // Assert
             Assert.NotNull(resourceEntity);


### PR DESCRIPTION
Products and Resources modules were not using the newly integrated option to link `IPersistetObject` object to corresponding entities when they were created. The custom way of the modules caused issues, thereby the new way is used now in both modules.